### PR TITLE
Follow crystal 0.36.1

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -4,6 +4,10 @@ version: 0.1.0
 authors:
   - Kepler Sticka-Jones <kepler@stickajones.org>
 
-crystal: 0.24.1
+crystal: 0.36.1
 
 license: MIT
+
+dependencies:
+  json_mapping:
+    github: crystal-lang/json_mapping.cr

--- a/src/lsp.cr
+++ b/src/lsp.cr
@@ -1,4 +1,5 @@
 require "json"
+require "json_mapping"
 require "./lsp/*"
 
 # TODO: Write documentation for `LSP`

--- a/src/lsp/protocol/response_message.cr
+++ b/src/lsp/protocol/response_message.cr
@@ -1,3 +1,6 @@
+require "./text_edit"
+require "./symbol_information"
+
 module LSP::Protocol
   # Add a response type when needed
   alias ResponseTypes = Array(TextEdit) | Array(Location) | Array(SymbolInformation) | Array(CompletionItem) | CompletionItem | Hover | Location

--- a/src/lsp/protocol/symbol_information.cr
+++ b/src/lsp/protocol/symbol_information.cr
@@ -1,4 +1,3 @@
-require "json"
 require "./location"
 
 module LSP::Protocol

--- a/src/lsp/protocol/text_document_identifier.cr
+++ b/src/lsp/protocol/text_document_identifier.cr
@@ -1,5 +1,3 @@
-require "json"
-
 module LSP::Protocol
   struct TextDocumentIdentifier
     JSON.mapping({

--- a/src/lsp/protocol/trace.cr
+++ b/src/lsp/protocol/trace.cr
@@ -1,5 +1,3 @@
-require "json"
-
 module LSP::Protocol
   # The initial trace setting. If omitted trace is disabled ('off')
   # 'off' | 'messages' | 'verbose'

--- a/src/lsp/protocol/versioned_text_document_identifier.cr
+++ b/src/lsp/protocol/versioned_text_document_identifier.cr
@@ -1,5 +1,3 @@
-require "json"
-
 module LSP::Protocol
   struct VersionedTextDocumentIdentifier
     JSON.mapping({

--- a/src/lsp/protocol/void_params.cr
+++ b/src/lsp/protocol/void_params.cr
@@ -1,5 +1,3 @@
-require "json"
-
 module LSP::Protocol
   struct VoidParams
     def initialize(pull : JSON::PullParser)


### PR DESCRIPTION
Refs:

* https://github.com/crystal-lang/crystal/pull/9527
* https://github.com/crystal-lang-tools/scry/issues/179

I don't know the detail of the language changing of crystal. So I guess this PR does not actually support latest language specs.
But currently we can't even finish running tests in crystal 0.36.1 and I guess it is the cause of https://github.com/crystal-lang-tools/scry/issues/179.